### PR TITLE
Playertime

### DIFF
--- a/src/com/github/unchama/player/time/PlayerTimeManager.java
+++ b/src/com/github/unchama/player/time/PlayerTimeManager.java
@@ -84,7 +84,7 @@ public class PlayerTimeManager extends DataManager implements UsingSql {
 		return Util.toTimeString(Util.toSecond(playtick - totalidletick));
 	}
 
-	//累計ログイン時間のgetset
+	//累計ログイン時間のgetterとsetter
 	public int getPlaytick(){
 		return playtick;
 	}
@@ -92,7 +92,7 @@ public class PlayerTimeManager extends DataManager implements UsingSql {
 		playtick = playtick_;
 	}
 
-	//累計放置時間のgetset
+	//累計放置時間のgetterとsetter
 	public int getTotalIdletick(){
 		return totalidletick;
 	}

--- a/src/com/github/unchama/player/time/PlayerTimeManager.java
+++ b/src/com/github/unchama/player/time/PlayerTimeManager.java
@@ -1,26 +1,29 @@
 package com.github.unchama.player.time;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 
 import com.github.unchama.player.GiganticPlayer;
 import com.github.unchama.player.moduler.DataManager;
 import com.github.unchama.player.moduler.UsingSql;
 import com.github.unchama.sql.PlayerTimeTableManager;
 import com.github.unchama.util.Util;
+import com.github.unchama.yml.DebugManager.DebugEnum;
 
 public class PlayerTimeManager extends DataManager implements UsingSql {
 
 	//プレイ時間差分計算用int
-	public int servertick;
+	private int servertick;
 	//プレイ時間
-	public int playtick;
+	private int playtick;
 
 	//現在座標
-	public Location loc;
+	private Location loc;
 	//累計放置時間
-	public int totalidletick;
+	private int totalidletick;
 	//放置時間
-	public int idletime;
+	private int idletime;
 
 	PlayerTimeTableManager tm = sql.getManager(PlayerTimeTableManager.class);
 
@@ -30,7 +33,45 @@ public class PlayerTimeManager extends DataManager implements UsingSql {
 
     @Override
     public void save(Boolean loginflag) {
+    	//セーブ前に時間を更新
+    	runUpdate();
         tm.save(gp, loginflag);
+    }
+
+    public void firstJoinInit(){
+    	reloadSevertick();
+		playtick = 0;
+		loc = null;
+		totalidletick = 0;
+		idletime = 0;
+		playtick = 0;
+    }
+
+    //1分毎にプレイ時間と待機時間を更新
+    public void runUpdate(){
+    	Player player = Bukkit.getServer().getPlayer(gp.uuid);
+		int getservertick = player.getStatistic(org.bukkit.Statistic.PLAY_ONE_TICK);
+		int getincrease = getservertick - servertick;
+		servertick = getservertick;
+		playtick += getincrease;
+
+		//放置判定
+		if(player.getLocation().equals(loc)){
+			if(isIdle()){
+				//既に放置中なら累計放置時間を追加
+				totalidletick += getincrease;
+			}
+			idletime ++;
+		}else{
+			loc = player.getLocation();
+			idletime = 0;
+		}
+		debug.sendMessage(player,DebugEnum.GUI,"プレイ時間更新"
+				+ ":servertick " + servertick
+				+ ":playtick " + playtick
+				+ ":totalidletick " + totalidletick
+				+ ":idletime " + idletime
+				);
     }
 
 	//10分間動きがなければ放置
@@ -41,5 +82,27 @@ public class PlayerTimeManager extends DataManager implements UsingSql {
 	//放置時間を除いた累計プレイ時間を「HH時間MM分」の文字列で返す
 	public String GetTotalLoginTimeToString(){
 		return Util.toTimeString(Util.toSecond(playtick - totalidletick));
+	}
+
+	//累計ログイン時間のgetset
+	public int getPlaytick(){
+		return playtick;
+	}
+	public void setPlaytick(int playtick_){
+		playtick = playtick_;
+	}
+
+	//累計放置時間のgetset
+	public int getTotalIdletick(){
+		return totalidletick;
+	}
+	public void setTotalIdletick(int totalidletick_){
+		totalidletick = totalidletick_;
+	}
+
+	//servertickをリロード
+	public void reloadSevertick(){
+    	Player player = Bukkit.getServer().getPlayer(gp.uuid);
+		servertick = player.getStatistic(org.bukkit.Statistic.PLAY_ONE_TICK);
 	}
 }

--- a/src/com/github/unchama/sql/PlayerTimeTableManager.java
+++ b/src/com/github/unchama/sql/PlayerTimeTableManager.java
@@ -25,33 +25,29 @@ public class PlayerTimeTableManager extends PlayerFromSeichiTableManager{
 	@Override
 	public void loadPlayer(GiganticPlayer gp, ResultSet rs) throws SQLException {
 		PlayerTimeManager m = gp.getManager(PlayerTimeManager.class);
-		m.playtick = rs.getInt("playtick");
-		m.totalidletick = rs.getInt("totalidletick");
+		m.setPlaytick(rs.getInt("playtick"));
+		m.setTotalIdletick(rs.getInt("totalidletick"));
+		m.reloadSevertick();
 	}
 
 	@Override
 	protected String saveCommand(GiganticPlayer gp) {
 		PlayerTimeManager m = gp.getManager(PlayerTimeManager.class);
-        String command = "";
-        command += "playtick = '" + m.playtick + "',"
-        		+ "totalidletick = '" + m.totalidletick + "',";
+		String command = "";
+        command += "playtick = '" + m.getPlaytick() + "',"
+        		+ "totalidletick = '" + m.getTotalIdletick() + "',";
         return command;
 	}
 
 	@Override
 	protected void takeoverPlayer(GiganticPlayer gp, PlayerDataTableManager tm) {
 		PlayerTimeManager m = gp.getManager(PlayerTimeManager.class);
-		m.playtick = tm.getPlayTick(gp);
+		m.setPlaytick(tm.getPlayTick(gp));
 	}
 
 	@Override
 	protected void firstjoinPlayer(GiganticPlayer gp) {
 		PlayerTimeManager m = gp.getManager(PlayerTimeManager.class);
-		m.servertick = 0;
-		m.playtick = 0;
-		m.loc = null;
-		m.totalidletick = 0;
-		m.idletime = 0;
-		m.playtick = 0;
+		m.firstJoinInit();
 	}
 }

--- a/src/com/github/unchama/task/PlayerTimeTaskRunnable.java
+++ b/src/com/github/unchama/task/PlayerTimeTaskRunnable.java
@@ -14,7 +14,6 @@ import com.github.unchama.player.GiganticStatus;
 import com.github.unchama.player.time.PlayerTimeManager;
 import com.github.unchama.yml.ConfigManager;
 import com.github.unchama.yml.DebugManager;
-import com.github.unchama.yml.DebugManager.DebugEnum;
 
 public class PlayerTimeTaskRunnable extends BukkitRunnable{
 	Gigantic plugin = Gigantic.plugin;
@@ -33,7 +32,7 @@ public class PlayerTimeTaskRunnable extends BukkitRunnable{
 
 	@Override
 	public void run() {
-		//TODO:ここで1分ごとに1minを0に設定
+		//1分毎にプレイ時間と待機時間を更新
 		Bukkit.getScheduler().runTask(plugin, new Runnable() {
 			@Override
 			public void run(){
@@ -48,41 +47,7 @@ public class PlayerTimeTaskRunnable extends BukkitRunnable{
 						GiganticStatus gs = PlayerManager.getStatus(gp);
 						if(gs.equals(GiganticStatus.AVAILABLE)){
 							PlayerTimeManager timeMng = gp.getManager(PlayerTimeManager.class);
-
-							//プレイ時間追加
-							int getservertick = player.getStatistic(org.bukkit.Statistic.PLAY_ONE_TICK);
-							int getincrease = getservertick - timeMng.servertick;
-							timeMng.servertick = getservertick;
-							timeMng.playtick += getincrease;
-
-							//放置判定
-							if(player.getLocation().equals(timeMng.loc)){
-								if(timeMng.isIdle()){
-									//既に放置中なら累計放置時間を追加
-									timeMng.totalidletick += getincrease;
-								}
-								timeMng.idletime ++;
-							}else{
-								timeMng.loc = player.getLocation();
-								timeMng.idletime = 0;
-							}
-							debug.sendMessage(player,DebugEnum.GUI,"プレイ時間更新"
-									+ ":servertick " + timeMng.servertick
-									+ ":playtick " + timeMng.playtick
-									+ ":totalidletick " + timeMng.totalidletick
-									+ ":idletime " + timeMng.idletime
-									);
-
-
-//							if(SeichiAssist.DEBUG){
-//								p.sendMessage("総プレイ時間に追加したtick:" + getincrease);
-//							}
-//								if(SeichiAssist.DEBUG){
-//									Util.sendEveryMessage(playerdata.name + "のidletime加算" + playerdata.idletime);
-//								}
-//								if(SeichiAssist.DEBUG){
-//									Util.sendEveryMessage(playerdata.name + "のidletimeリセット");
-//								}
+							timeMng.runUpdate();
 						}
 					}
 				}


### PR DESCRIPTION
publicだったメンバーのgetterとsetterを追加
更新処理をマネージャー本体に移動
ログアウト、サーバー終了時に数値が反映されるように
Init関数の名前を変更
load時のservertickを初期化するように